### PR TITLE
Add Service Principal parameters to the Add-AzureRMServiceEndpoint cmdlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ To get started you can visit this blog [PowerShell I would like you to meet TFS 
 The cases of every file is very important. This module is to be used on Windows, Linux and OSx so case is important.  If the casing does not match Linux and OSx might fail.
 
 # Release Notes
+## 0.1.20
+Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/6)from [Michel Perfetti](https://github.com/miiitch) which included the following:
+
+- Added serviceEndpoint parameters to Add-AzureRMServiceEndpoint cmdlet: if the serviceEndPoint parameters are not specified, the Automatic mode is used
+- The _trackProgress function was changed too to reflect the return code of the api (https://www.visualstudio.com/en-us/docs/integrate/api/endpoints/endpoints)
+- The URL in the payload changed to https://management.azure.com
+
 ## 0.1.19
 Removed test folder from module
 

--- a/Team.psd1
+++ b/Team.psd1
@@ -13,7 +13,7 @@
    RootModule = ''
 
    # Version number of this module.
-   ModuleVersion = '0.1.19'
+   ModuleVersion = '0.1.20'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/src/serviceendpoints.psm1
+++ b/src/serviceendpoints.psm1
@@ -85,8 +85,8 @@ function _trackProgress {
    $url = _buildURL -projectName $projectName -id $resp.id
 
    # Track status
-   while ($status -ne 'Failed' -and $status -ne 'Ready') {
-      $status = (_checkStatus $url).operationStatus.state
+   while ($status -ne '$true') {
+      $status = (_checkStatus $url).isReady
 
       # oscillate back a forth to show progress
       $i += $x
@@ -142,7 +142,9 @@ function Add-AzureRMServiceEndpoint {
       [string] $subscriptionId,
       [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
       [string] $subscriptionTenantId,
-      [string] $endpointName
+      [string] $endpointName,
+      [string] $servicePrincipalId,
+      [string] $servicePrincipalKey
    )
 
    DynamicParam {
@@ -160,11 +162,20 @@ function Add-AzureRMServiceEndpoint {
          $endpointName = $displayName
       }
 
+      if (-not $servicePrincipalId) {
+          $creationMode = "Automatic"
+          $servicePrincipalId=""
+          $servicePrincipalKey=""
+      }
+      else {
+        $creationMode = "Manual"
+      }
+
       $obj = @{
          authorization=@{
             parameters=@{
-               serviceprincipalid='';
-               serviceprincipalkey='';
+               serviceprincipalid=$servicePrincipalId;
+               serviceprincipalkey=$servicePrincipalKey;
                tenantid=$subscriptionTenantId
             };
             scheme='ServicePrincipal'
@@ -172,11 +183,11 @@ function Add-AzureRMServiceEndpoint {
          data=@{
             subscriptionId=$subscriptionId;
             subscriptionName=$displayName;
-            creationMode='Automatic'
+            creationMode=$creationMode
          };
          name=$endpointName;
          type='azurerm';
-         url='https://management.core.windows.net/'
+         url='https://management.azure.com/'
       }
 
       $body = $obj | ConvertTo-Json

--- a/test/serviceendpoints.Tests.ps1
+++ b/test/serviceendpoints.Tests.ps1
@@ -50,10 +50,14 @@ InModuleScope serviceendpoints {
             # This $i is in the module. Because we use InModuleScope
             # we can see it
             if ($i -gt 9) {
-               return @{operationStatus=@{state='Ready'}}
+               return @{
+                  isReady=$true
+                  operationStatus=@{state='Ready'}
+               }
             }
 
             return @{
+               isReady=$false
                createdBy=@{}
                authorization=@{}
                data=@{}


### PR DESCRIPTION
This PR has 3 parts:
* add serviceEndpoint parameters in Add-AzureRMServiceEndpoint cmdlet: if the serviceEndPoint parameters are not specified, the Automatic mode is used 
* the _trackProgress function is changed too to reflect the return code of the api (https://www.visualstudio.com/en-us/docs/integrate/api/endpoints/endpoints)
* the URL in the payload changed to https://management.azure.com