### PR TITLE
Adding a regular expression to validate VSTS account

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ To get started you can visit this blog [PowerShell I would like you to meet TFS 
 The cases of every file is very important. This module is to be used on Windows, Linux and OSx so case is important.  If the casing does not match Linux and OSx might fail.
 
 # Release Notes
+## 0.1.26
+Merge [Pull Request](https://github.com/DarqueWarrior/team/pull/10) from [Roberto Peña](https://github.com/eulesv) which included the following:
+
+- Adding a regular expression to validate VSTS account
+
 ## 0.1.25
 - Moved -Expand parameter of Get-Release to all parameter sets.
 

--- a/Team.psd1
+++ b/Team.psd1
@@ -13,7 +13,7 @@
    RootModule = ''
 
    # Version number of this module.
-   ModuleVersion = '0.1.25'
+   ModuleVersion = '0.1.26'
 
    # Supported PSEditions
    # CompatiblePSEditions = @()

--- a/src/team.psm1
+++ b/src/team.psm1
@@ -151,8 +151,8 @@ function Add-TeamAccount {
       }
 
       # If they only gave an account name add visualstudio.com
-      if($Account.ToLower().Contains('http') -eq $false) {
-         $Account = "https://$($Account).visualstudio.com"
+      if($Account -match  "(?<protocol>https?\://)?(?<account>[A-Z0-9][-A-Z0-9]*[A-Z0-9])(?<domain>\.visualstudio\.com)?") {
+         $Account = "https://$($matches.account).visualstudio.com"
       }
 
       $encodedPat = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$_pat"))


### PR DESCRIPTION
A simple fix in case someone provides an account without protocol (account.visualstudio.com) or if the name includes http (for example myhttpaccount as account name)